### PR TITLE
Implement IEquatable for all structs

### DIFF
--- a/Runtime/RewiredAction.cs
+++ b/Runtime/RewiredAction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace Valax321.RewiredActionProperty
     /// Wrapper class for a Rewired action ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredAction
+    public struct RewiredAction : IEquatable<RewiredAction>
     {
         [SerializeField] private int m_actionID;
 
@@ -29,6 +30,31 @@ namespace Valax321.RewiredActionProperty
         public static implicit operator int(RewiredAction @this)
         {
             return @this.m_actionID;
+        }
+
+        public bool Equals(RewiredAction other)
+        {
+            return m_actionID == other.m_actionID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredAction other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return actionID;
+        }
+
+        public static bool operator ==(RewiredAction left, RewiredAction right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredAction left, RewiredAction right)
+        {
+            return !left.Equals(right);
         }
     }
 }

--- a/Runtime/RewiredLayout.cs
+++ b/Runtime/RewiredLayout.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Valax321.RewiredActionProperty
@@ -12,12 +13,12 @@ namespace Valax321.RewiredActionProperty
         /// </summary>
         int layoutID { get; }
     }
-    
+
     /// <summary>
     /// Wrapper class for a Rewired joystick layout ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredJoystickLayout : IRewiredLayout
+    public struct RewiredJoystickLayout : IRewiredLayout, IEquatable<RewiredJoystickLayout>
     {
         [SerializeField] private int m_layoutID;
         public int layoutID => m_layoutID;
@@ -26,10 +27,35 @@ namespace Valax321.RewiredActionProperty
         {
             m_layoutID = layoutID;
         }
-        
+
         public static implicit operator int(RewiredJoystickLayout @this)
         {
             return @this.m_layoutID;
+        }
+
+        public bool Equals(RewiredJoystickLayout other)
+        {
+            return m_layoutID == other.m_layoutID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredJoystickLayout other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return layoutID;
+        }
+
+        public static bool operator ==(RewiredJoystickLayout left, RewiredJoystickLayout right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredJoystickLayout left, RewiredJoystickLayout right)
+        {
+            return !left.Equals(right);
         }
     }
 
@@ -37,19 +63,44 @@ namespace Valax321.RewiredActionProperty
     /// Wrapper class for a Rewired keyboard layout ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredKeyboardLayout : IRewiredLayout
+    public struct RewiredKeyboardLayout : IRewiredLayout, IEquatable<RewiredKeyboardLayout>
     {
         [SerializeField] private int m_layoutID;
         public int layoutID => m_layoutID;
-        
+
         public RewiredKeyboardLayout(int layoutID)
         {
             m_layoutID = layoutID;
         }
-        
+
         public static implicit operator int(RewiredKeyboardLayout @this)
         {
             return @this.m_layoutID;
+        }
+
+        public bool Equals(RewiredKeyboardLayout other)
+        {
+            return m_layoutID == other.m_layoutID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredKeyboardLayout other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return layoutID;
+        }
+
+        public static bool operator ==(RewiredKeyboardLayout left, RewiredKeyboardLayout right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredKeyboardLayout left, RewiredKeyboardLayout right)
+        {
+            return !left.Equals(right);
         }
     }
 
@@ -57,27 +108,52 @@ namespace Valax321.RewiredActionProperty
     /// Wrapper class for a Rewired mouse layout ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredMouseLayout : IRewiredLayout
+    public struct RewiredMouseLayout : IRewiredLayout, IEquatable<RewiredMouseLayout>
     {
         [SerializeField] private int m_layoutID;
         public int layoutID => m_layoutID;
-        
+
         public RewiredMouseLayout(int layoutID)
         {
             m_layoutID = layoutID;
         }
-        
+
         public static implicit operator int(RewiredMouseLayout @this)
         {
             return @this.m_layoutID;
         }
+
+        public bool Equals(RewiredMouseLayout other)
+        {
+            return m_layoutID == other.m_layoutID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredMouseLayout other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return layoutID;
+        }
+
+        public static bool operator ==(RewiredMouseLayout left, RewiredMouseLayout right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredMouseLayout left, RewiredMouseLayout right)
+        {
+            return !left.Equals(right);
+        }
     }
-    
+
     /// <summary>
     /// Wrapper class for a Rewired custom controller layout ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredCustomControllerLayout : IRewiredLayout
+    public struct RewiredCustomControllerLayout : IRewiredLayout, IEquatable<RewiredCustomControllerLayout>
     {
         [SerializeField] private int m_layoutID;
         public int layoutID => m_layoutID;
@@ -86,10 +162,35 @@ namespace Valax321.RewiredActionProperty
         {
             m_layoutID = layoutID;
         }
-        
+
         public static implicit operator int(RewiredCustomControllerLayout @this)
         {
             return @this.m_layoutID;
+        }
+
+        public bool Equals(RewiredCustomControllerLayout other)
+        {
+            return m_layoutID == other.m_layoutID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredCustomControllerLayout other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return layoutID;
+        }
+
+        public static bool operator ==(RewiredCustomControllerLayout left, RewiredCustomControllerLayout right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredCustomControllerLayout left, RewiredCustomControllerLayout right)
+        {
+            return !left.Equals(right);
         }
     }
 }

--- a/Runtime/RewiredMapCategory.cs
+++ b/Runtime/RewiredMapCategory.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Valax321.RewiredActionProperty
@@ -6,7 +7,7 @@ namespace Valax321.RewiredActionProperty
     /// Wrapper class for a Rewired map category ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredMapCategory
+    public struct RewiredMapCategory : IEquatable<RewiredMapCategory>
     {
         [SerializeField] private int m_categoryID;
 
@@ -27,6 +28,31 @@ namespace Valax321.RewiredActionProperty
         public static implicit operator int(RewiredMapCategory @this)
         {
             return @this.m_categoryID;
+        }
+
+        public bool Equals(RewiredMapCategory other)
+        {
+            return m_categoryID == other.m_categoryID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredMapCategory other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return categoryID;
+        }
+
+        public static bool operator ==(RewiredMapCategory left, RewiredMapCategory right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredMapCategory left, RewiredMapCategory right)
+        {
+            return !left.Equals(right);
         }
     }
 }

--- a/Runtime/RewiredPlayer.cs
+++ b/Runtime/RewiredPlayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace Valax321.RewiredActionProperty
     /// Wrapper for a Rewired player ID.
     /// </summary>
     [System.Serializable]
-    public struct RewiredPlayer
+    public struct RewiredPlayer : IEquatable<RewiredPlayer>
     {
         [SerializeField] private int m_actionID;
 
@@ -29,6 +30,31 @@ namespace Valax321.RewiredActionProperty
         public static implicit operator int(RewiredPlayer @this)
         {
             return @this.m_actionID;
+        }
+
+        public bool Equals(RewiredPlayer other)
+        {
+            return m_actionID == other.m_actionID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RewiredPlayer other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return actionID;
+        }
+
+        public static bool operator ==(RewiredPlayer left, RewiredPlayer right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RewiredPlayer left, RewiredPlayer right)
+        {
+            return !left.Equals(right);
         }
     }
 }


### PR DESCRIPTION
The default `GetHashCode()` and `Equals()` methods for `struct`s are slow and use reflection. Check out the definition of `System.ValueType` to see what I mean. This PR properly implements those methods.